### PR TITLE
Update webpack query parsing tested with SSR & add options

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,4 +1,3 @@
-
 # VueGlobalRegistration ![CI status](https://img.shields.io/badge/build-passing-brightgreen.svg)
 
 Register globally components with name based on folder and generate routing based on folder and filename
@@ -27,13 +26,28 @@ You will need to add in the rules of your module key in your webpack configurati
    {
         enforce: "pre",
         test: /app.js/,
-        loader: VueGlobalRegistration.Register({
+        loader: 'vueglobalregistration-webpack-plugin',
+        options: {
             type: "component",
             folder :  __dirname +  "/../src/components",
             recursive : true
+        }
+   }
+```
+
+If you want to add some `regular expressions` to your options config, webpack will not be able to serialize them correctly. You will need to provide their source like this `/test.vue/.source` or use our `Register` method which will automatically parse regular expressions.
+```js
+   {
+        enforce: "pre",
+        test: /app.js/,
+        loader: VueGlobalRegistration.Register({
+            type: "routing",
+            folder :  __dirname +  "/../src/components",
+            recursive : true,
+            test: /index.vue/ //Will only accept index.vue files instead of all detected .vue files
         })
-    }
-``` 
+   }
+```
 ### Result
 When the type is `component` it will generate based on your folder structure the code to register the component. It will inject the code in the file (here it will be the `app.js`)
 
@@ -63,7 +77,8 @@ webpack.config.js
         test: /app.js/,
         loader: VueGlobalRegistration.Register({
             type: "component",
-            replace : "//<component>"
+            //importPrefix: 'COMP', optionaly replace the default used prefix (for instance when multiple loaders are used)
+            replace : "//<component>",
             folder :  __dirname +  "/../src/components",
             recursive : true
         })

--- a/index.js
+++ b/index.js
@@ -1,15 +1,13 @@
+module.exports = require('./loader.js');
 
-var opts = {};
-var cache =  {};
-function VueGlobalRegistration() {}
+function parser(key, value) {
+  if (value instanceof RegExp)
+    return value.source;
+  else
+    return value;
+}
 
-// export the replacement options
-// so that the loader can refer to them
-VueGlobalRegistration.RegistrationOptions = opts;
-VueGlobalRegistration.RegistrationCache = cache;
-module.exports = VueGlobalRegistration;
-
-VueGlobalRegistration.Register = function(nextLoaders, registerOptions, prevLoaders) {
+module.exports.Register = function(nextLoaders, registerOptions, prevLoaders) {
     // shift params to account for optional nextLoaders
     if(!prevLoaders && (typeof registerOptions === "string")) {
         prevLoaders = registerOptions;
@@ -20,9 +18,8 @@ VueGlobalRegistration.Register = function(nextLoaders, registerOptions, prevLoad
         nextLoaders = undefined;
     }
 
-    var id = Math.random().toString(36).slice(2);
-    opts[id] = registerOptions;
-    var replaceLoader = require.resolve("./loader") + "?id=" + id,
+    const query = JSON.stringify(registerOptions, parser, 2);
+    var replaceLoader = require.resolve("./loader") + "?" + query,
         val = replaceLoader;
     if(nextLoaders || prevLoaders) {
         var loaders = [replaceLoader];
@@ -30,10 +27,6 @@ VueGlobalRegistration.Register = function(nextLoaders, registerOptions, prevLoad
         if(prevLoaders) loaders.push(prevLoaders);
         val = loaders.join("!");
     }
-    
+
     return val;
-};
-
-
-VueGlobalRegistration.prototype.apply = function(compiler) {
-};
+}


### PR DESCRIPTION
- Tested with SSR
- Add test parameter to routing options in order to filter accepted routes
- Add importPrefix option in order to prevent double names when using multiple loaders on different folders
- Parse options as query parameter in order to enable webpack worker bundling